### PR TITLE
Fix npm MODULE_NOT_FOUND error in publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,17 +13,17 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      
+      - uses: actions/checkout@v4
+
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
-          
+
       - name: Update npm to latest
         run: npm install -g npm@latest
-      
+
       - name: Install dependencies
         run: npm ci
       


### PR DESCRIPTION
Update actions to v4 to fix corrupted npm in Node 22.22.2 toolcache.