### PR TITLE
Pin Node to 22.14.0 to fix corrupted npm toolcache

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,11 +18,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Update npm to latest
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Node 22.22.2 has a broken npm installation on GitHub Actions runners. Pin to 22.14.0 which has a working toolcache.