### PR TITLE
ci: track latest LTS Node instead of pinning 22.14.0

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
+          node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
## Problem

The NPM Publish workflow fails roughly every 3 months. Latest failure: [run 29102549589](https://github.com/gonativeio/median-javascript-bridge/actions/runs/29102549589/job/86394828430).

```
npm error engine Not compatible with your version of node/npm: npm@12.0.0
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.2","node":"v22.14.0"}
```

## Root cause

The workflow pinned `node-version: '22.14.0'` (an exact, frozen patch) but the `Update npm for provenance support` step runs `npm install -g npm@latest`. npm cuts a new **major** ~quarterly, and each major raises its minimum Node floor. Once npm's floor climbed past the frozen Node (npm@12 needs `>=22.22.2`), the install tripped `EBADENGINE` and the whole job failed. This is why it breaks on a recurring ~3-month cadence rather than being a token/credential expiry.

## Fix

Pin to `lts/*`, which resolves to the current latest LTS (Node 24.x) at run time. Node can no longer drift behind npm's minimum, so the recurring collision is eliminated.

## Testing

- Reproduced CI steps locally (`npm ci` → `npm run lint` → `npm run build`) on Node 22.17.1 — all pass.
- Could not exercise Node 24 exactly (no local version manager / Docker daemon), but the toolchain (tsc + rollup + eslint) is not sensitive to the 22→24 jump.

## Note

The `npm install -g npm@latest` step is now effectively redundant — the npm bundled with a current LTS Node already supports `--provenance`. It could be dropped as further cleanup, but this PR keeps the change minimal.