### PR TITLE
ci: drop redundant 'npm install -g npm@latest' (fixes sigstore MODULE_NOT_FOUND on publish)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Update npm for provenance support
-        run: npm install -g npm@latest
-
       - name: Check if version is published
         id: check-version
         run: |


### PR DESCRIPTION
## Problem

Follow-up to #146. With `lts/*` in place the EBADENGINE failure is gone (build now runs on Node 24.18.0), but the **publish** step now fails: [run 29104808669](https://github.com/gonativeio/median-javascript-bridge/actions/runs/29104808669/job/86402504522).

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
npm error - /opt/hostedtoolcache/node/24.18.0/x64/lib/node_modules/npm/node_modules/libnpmpublish/lib/provenance.js
```

## Root cause

The `Update npm for provenance support` step runs `npm install -g npm@latest`, overwriting the toolcache's bundled npm. That npm-over-npm install lands a global npm whose `sigstore` dependency is missing, so `npm publish --provenance` blows up with `MODULE_NOT_FOUND` the moment it tries to generate the provenance attestation.

## Fix

Delete the step. The npm bundled with a current LTS Node (npm 11.x on Node 24.18.0) already supports `--provenance` with `sigstore` intact, so publishing with the bundled npm just works. This also removes the last moving-version failure point in the workflow — nothing left to drift or self-corrupt.

## Testing

- `npm ci` → `npm run lint` → `npm run build` pass locally.
- The removed step had no effect on build output; it only touched the global npm used for publish.