### PR TITLE
Send the Android auth0 getCredentials command path

### DIFF
--- a/src/plugins/auth0.ts
+++ b/src/plugins/auth0.ts
@@ -1,5 +1,5 @@
 import { AnyData, CallbackParams } from '../types/index.js';
-import { addCommandCallback } from '../utils/index.js';
+import { addCommandCallback, isAndroid } from '../utils/index.js';
 import { AuthStatusData } from './auth.js';
 
 type Auth0LoginData = {
@@ -34,8 +34,12 @@ const auth0 = {
   profile: function (params: Auth0ProfileParams) {
     return addCommandCallback<Auth0LoginData>('median://auth0/profile', params);
   },
+  get: function (params: CallbackParams<Auth0LoginData>) {
+    return auth0.getCredentials(params);
+  },
   getCredentials: function (params: CallbackParams<Auth0LoginData>) {
-    return addCommandCallback<Auth0LoginData>('median://auth0/getCredentials', params);
+    const command = isAndroid() ? 'median://auth0/get' : 'median://auth0/getCredentials';
+    return addCommandCallback<Auth0LoginData>(command, params);
   },
   renew: function (refreshToken?: string) {
     return addCommandCallback<Auth0LoginData>('median://auth0/renew', { refreshToken });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,6 +19,10 @@ export function createTempFunctionName(prefix = '_median_temp_') {
   return prefix + Math.random().toString(36).slice(2);
 }
 
+export function isAndroid() {
+  return !!window?.JSBridge?.postMessage;
+}
+
 // GoNativeJSBridgeLibrary.js
 export function addCallbackFunction(callbackFunction: string | ((data?: AnyData) => void), persistCallback?: boolean) {
   if (typeof callbackFunction === 'string') {


### PR DESCRIPTION
`median://auth0/get` was renamed to `median://auth0/getCredentials` across all three repos on 2024-05-06, and Android finished the rename in `2f27464` "Fix getCredentials uri" (2024-06-19). When the plugin was imported into the consolidated `android-plugins` repo on 2025-02-20, the import used a pre-June-2024 snapshot and silently reverted Android to `/get` — along with the audience param, which was later re-implemented as #1080.

The plugin claims the `auth0` host and returns true for any path under it, so the unmatched command is swallowed with no callback: the promise never settles or rejects, and pages awaiting credentials on Android hang forever. Only apps loading this package hit it (`injectMedianJS: false`); the app-injected polyfill sends `/get` and stays self-consistent.

This resolves the path per platform and adds `get` as an alias, as both platform polyfills do. Verified on-device against a stuck client app: `getCredentials()` resolves with a valid `accessToken` where published 2.18.0 hangs.

Restoring `/getCredentials` in the Android plugin does not remove the need for this: every Android build already shipped carries a plugin that only answers `/get`, and those apps can only be fixed from the JS side. The native fix should accept both paths, which keeps this change correct either way.