### PR TITLE
Barcode scanner: add format whitelist to scan

### DIFF
--- a/src/plugins/barcode.ts
+++ b/src/plugins/barcode.ts
@@ -29,7 +29,7 @@ type BarcodeScanParams = CallbackParams<BarcodeScanData> & {
 };
 
 const barcode = {
-  scan: function (params: BarcodeScanParams) {
+  scan: function (params?: BarcodeScanParams) {
     return addCommandCallback<BarcodeScanData>('median://barcode/scan', params);
   },
   setPrompt: function (prompt: string) {

--- a/src/plugins/barcode.ts
+++ b/src/plugins/barcode.ts
@@ -1,6 +1,21 @@
 import { CallbackParams } from '../types/index.js';
 import { addCommand, addCommandCallback } from '../utils/index.js';
 
+type BarcodeFormat =
+  | 'QR_CODE'
+  | 'DATA_MATRIX'
+  | 'AZTEC'
+  | 'PDF_417'
+  | 'EAN_13'
+  | 'EAN_8'
+  | 'UPC_A'
+  | 'UPC_E'
+  | 'CODE_39'
+  | 'CODE_93'
+  | 'CODE_128'
+  | 'ITF'
+  | 'CODABAR';
+
 type BarcodeScanData = {
   success: boolean;
   type?: string;
@@ -8,8 +23,13 @@ type BarcodeScanData = {
   error?: string;
 };
 
+type BarcodeScanParams = CallbackParams<BarcodeScanData> & {
+  // Whitelist of symbologies that auto-trigger a scan. Empty/omitted = scan all.
+  formats?: BarcodeFormat[];
+};
+
 const barcode = {
-  scan: function (params: CallbackParams<BarcodeScanData>) {
+  scan: function (params: BarcodeScanParams) {
     return addCommandCallback<BarcodeScanData>('median://barcode/scan', params);
   },
   setPrompt: function (prompt: string) {


### PR DESCRIPTION
Adds an optional `formats` array to `barcode.scan`. When omitted or empty, all symbologies are scanned (unchanged). When set, only the listed formats trigger a scan. Adds a `BarcodeFormat` union type for autocomplete.

Supported tokens: `QR_CODE`, `DATA_MATRIX`, `AZTEC`, `PDF_417`, `EAN_13`, `EAN_8`, `UPC_A`, `UPC_E`, `CODE_39`, `CODE_93`, `CODE_128`, `ITF`, `CODABAR`.