### PR TITLE
Re-subscribe listeners after a back-forward cache restore

### DIFF
--- a/src/utils/listener.ts
+++ b/src/utils/listener.ts
@@ -21,6 +21,20 @@ function setSubscription(eventName: string, subscribe: boolean) {
   }
 }
 
+// A back-forward cache restore reuses the document without re-running scripts,
+// so the page never re-sends median://events/subscribe. Re-subscribe for it.
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  window.addEventListener('pageshow', (event) => {
+    if ((event as PageTransitionEvent).persisted) {
+      Object.keys(listeners).forEach((functionName) => {
+        if (Object.keys(listeners[functionName]).length > 0) {
+          setSubscription(functionName, true);
+        }
+      });
+    }
+  });
+}
+
 const addListener = <T>(functionName: string, callback: (data: T) => void) => {
   const functionId = createTempFunctionName(functionName);
 


### PR DESCRIPTION
When iOS clears event subscriptions on `didCommitNavigation`, a back-forward restore that reuses the document re-clears them - but the page's scripts don't re-run, so nothing calls `addListener` again, and every listener on the page dies silently.

`pageshow` with `persisted: true` is the one signal that fires on a bfcache restore. On it, re-send `median://events/subscribe` for every event name that still has a registered callback.